### PR TITLE
Changed zero-dimension (width/height) handling to be the same as Hipp…

### DIFF
--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/ImageDimension.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/ImageDimension.java
@@ -84,6 +84,27 @@ public class ImageDimension implements Serializable {
         return new StringBuilder(20).append(width).append('x').append(height).toString();
     }
 
+    /**
+     * @return String representation for ImageMagick/GraphicsMagick command line usage.
+     * A width or height of 0 means "unbounded", and results in a bounding box that does not restrict scaling in either
+     * the width or height, respectively.
+     * When both width and height are 0 or less, the image is not scaled at all but merely copied.
+     */
+    public String toCommandArgument() {
+        StringBuilder arg = new StringBuilder(20);
+        if (width == 0 && height == 0) { //no resize
+            arg.append("100%");
+        }
+        if (width > 0) {
+            arg.append(width);
+        }
+        if (height > 0) {
+            arg.append('x').append(height);
+        }
+
+        return arg.toString();
+    }
+
     public static ImageDimension from(final int width, final int height) {
         if (width < 0 || height < 0) {
             throw new IllegalArgumentException("Invalid width or height.");

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtils.java
@@ -121,7 +121,7 @@ public class GraphicsMagickCommandUtils {
 
         cmd.addArgument(sourceFile.getCanonicalPath());
         cmd.addArgument("-resize");
-        cmd.addArgument(dimension.toString());
+        cmd.addArgument(dimension.toCommandArgument());
 
         if (extraOptions != null) {
             for (String extraOption : extraOptions) {

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtils.java
@@ -121,7 +121,7 @@ public class ImageMagickCommandUtils {
 
         cmd.addArgument(sourceFile.getCanonicalPath());
         cmd.addArgument("-resize");
-        cmd.addArgument(dimension.toString());
+        cmd.addArgument(dimension.toCommandArgument());
 
         if (extraOptions != null) {
             for (String extraOption : extraOptions) {

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtils.java
@@ -31,6 +31,7 @@ import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.imgscalr.Scalr;
 import org.onehippo.forge.gallerymagick.core.ImageDimension;
 
@@ -117,8 +118,19 @@ public class ScalrProcessorUtils {
             }
 
             BufferedImage sourceImage = reader.read(0);
-            BufferedImage resizedImage = Scalr.resize(sourceImage, Scalr.Method.QUALITY, Scalr.Mode.AUTOMATIC,
-                    dimension.getWidth(), dimension.getHeight());
+            BufferedImage resizedImage;
+            if (dimension.getHeight() == 0 && dimension.getWidth() == 0) {
+                resizedImage = sourceImage;
+            } else {
+                Scalr.Mode mode = Scalr.Mode.AUTOMATIC;
+                if (dimension.getWidth() == 0) {
+                    mode = Scalr.Mode.FIT_TO_HEIGHT;
+                } else if (dimension.getHeight() == 0) {
+                    mode = Scalr.Mode.FIT_TO_WIDTH;
+                }
+                resizedImage = Scalr.resize(sourceImage, Scalr.Method.QUALITY, mode,
+                        dimension.getWidth(), dimension.getHeight());
+            }
 
             final ImageWriteParam writeParam = writer.getDefaultWriteParam();
 

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractGraphicsMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractGraphicsMagickCommandTest.java
@@ -41,6 +41,9 @@ abstract public class AbstractGraphicsMagickCommandTest extends AbstractMagickCo
             if (!_gmCommandAvailable && new File("/usr/local/bin/gm").isFile()) {
                 _gmCommandAvailable = true;
             }
+            if (!_gmCommandAvailable && new File("/opt/local/bin/gm").isFile()) {
+                _gmCommandAvailable = true;
+            }
         }
     }
 

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractImageMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractImageMagickCommandTest.java
@@ -22,12 +22,12 @@ import org.slf4j.LoggerFactory;
 
 abstract public class AbstractImageMagickCommandTest extends AbstractMagickCommandTest {
 
-    private static Logger log = LoggerFactory.getLogger(GraphicsMagickCommandUtilsTest.class);
+    private static Logger log = LoggerFactory.getLogger(AbstractImageMagickCommandTest.class);
 
     private static boolean _convertCommandAvailable;
 
     static {
-        final String executableFromSysProp = GraphicsMagickCommand.getExecutableFromSystemProperty();
+        final String executableFromSysProp = ImageMagickCommand.getExecutableFromSystemProperty("convert");
 
         if (executableFromSysProp != null) {
             _convertCommandAvailable = new File(executableFromSysProp).exists();
@@ -39,6 +39,9 @@ abstract public class AbstractImageMagickCommandTest extends AbstractMagickComma
                 _convertCommandAvailable = true;
             }
             if (!_convertCommandAvailable && new File("/usr/local/bin/convert").isFile()) {
+                _convertCommandAvailable = true;
+            }
+            if (!_convertCommandAvailable && new File("/opt/local/bin/convert").isFile()) {
                 _convertCommandAvailable = true;
             }
         }

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.onehippo.forge.gallerymagick.core.command;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -53,6 +54,7 @@ public class GraphicsMagickCommandUtilsTest extends AbstractGraphicsMagickComman
         String sourceFileName;
         String sourceExtension;
         String targetFileName;
+        ImageDimension dimension;
 
         for (File sourceFile : getTestImageFiles()) {
             sourceFileName = sourceFile.getName();
@@ -62,11 +64,39 @@ public class GraphicsMagickCommandUtilsTest extends AbstractGraphicsMagickComman
             long sourceLength = sourceFile.length();
             File targetFile = new File("target/testGraphicsMagickResizeImage-" + targetFileName);
 
+            targetFile.delete();
             GraphicsMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x120"), "+profile", "*");
 
             assertTrue(targetFile.isFile());
             assertTrue(targetFile.length() > 0L);
             assertTrue(targetFile.length() < sourceLength);
+
+            targetFile.delete();
+            GraphicsMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x0"), "+profile", "*");
+            dimension = GraphicsMagickCommandUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getWidth());
+
+            targetFile.delete();
+            GraphicsMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x120"), "+profile", "*");
+            dimension = GraphicsMagickCommandUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getHeight());
+
+            targetFile.delete();
+            GraphicsMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x0"), "+profile", "*");
+            dimension = GraphicsMagickCommandUtils.identifyDimension(targetFile);
+            ImageDimension sourceDimension = GraphicsMagickCommandUtils.identifyDimension(sourceFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertEquals(sourceDimension, dimension);
         }
     }
 

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.onehippo.forge.gallerymagick.core.command;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -53,6 +54,7 @@ public class ImageMagickCommandUtilsTest extends AbstractImageMagickCommandTest 
         String sourceFileName;
         String sourceExtension;
         String targetFileName;
+        ImageDimension dimension;
 
         for (File sourceFile : getTestImageFiles()) {
             sourceFileName = sourceFile.getName();
@@ -62,11 +64,39 @@ public class ImageMagickCommandUtilsTest extends AbstractImageMagickCommandTest 
             long sourceLength = sourceFile.length();
             File targetFile = new File("target/testImageMagickResizeImage-" + targetFileName);
 
+            targetFile.delete();
             ImageMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x120"), "+profile", "*");
 
             assertTrue(targetFile.isFile());
             assertTrue(targetFile.length() > 0L);
             assertTrue(targetFile.length() < sourceLength);
+
+            targetFile.delete();
+            ImageMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x0"), "+profile", "*");
+            dimension = ImageMagickCommandUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getWidth());
+
+            targetFile.delete();
+            ImageMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x120"), "+profile", "*");
+            dimension = ImageMagickCommandUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getHeight());
+
+            targetFile.delete();
+            ImageMagickCommandUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x0"), "+profile", "*");
+            dimension = ImageMagickCommandUtils.identifyDimension(targetFile);
+            ImageDimension sourceDimension = ImageMagickCommandUtils.identifyDimension(sourceFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertEquals(sourceDimension, dimension);
         }
     }
 

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.onehippo.forge.gallerymagick.core.command;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -48,6 +49,7 @@ public class ScalrProcessorUtilsTest extends AbstractMagickCommandTest {
         String sourceFileName;
         String sourceExtension;
         String targetFileName;
+        ImageDimension dimension;
 
         for (File sourceFile : getTestImageFiles()) {
             sourceFileName = sourceFile.getName();
@@ -57,11 +59,39 @@ public class ScalrProcessorUtilsTest extends AbstractMagickCommandTest {
             long sourceLength = sourceFile.length();
             File targetFile = new File("target/testScalrProcessorResizeImage-" + targetFileName);
 
+            targetFile.delete();
             ScalrProcessorUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x120"));
 
             assertTrue(targetFile.isFile());
             assertTrue(targetFile.length() > 0L);
             assertTrue(targetFile.length() < sourceLength);
+
+            targetFile.delete();
+            ScalrProcessorUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("120x0"));
+            dimension = ScalrProcessorUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getWidth());
+
+            targetFile.delete();
+            ScalrProcessorUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x120"));
+            dimension = ScalrProcessorUtils.identifyDimension(targetFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertTrue(targetFile.length() < sourceLength);
+            assertEquals(120, dimension.getHeight());
+
+            targetFile.delete();
+            ScalrProcessorUtils.resizeImage(sourceFile, targetFile, ImageDimension.from("0x0"));
+            dimension = ScalrProcessorUtils.identifyDimension(targetFile);
+            ImageDimension sourceDimension = ScalrProcessorUtils.identifyDimension(sourceFile);
+
+            assertTrue(targetFile.isFile());
+            assertTrue(targetFile.length() > 0L);
+            assertEquals(sourceDimension, dimension);
         }
     }
 


### PR DESCRIPTION
…o's default. i.e., A width or height of 0 means "unbounded", and results in a bounding box that does not restrict scaling in either the width or height, respectively. When both width and height are 0 or less, the image is not scaled at all but merely copied.