### PR TITLE
Feature/forge 618 upgrade brxm v17

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Gallery Magick Image Processing
-Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
 This product includes software developed by:
 Bloomreach B.V., Amsterdam, The Netherlands (http://www.bloomreach.com/);

--- a/README.md
+++ b/README.md
@@ -1,11 +1,52 @@
 # Gallery Magick Image Processing
 
-Gallery Magick Image Processing provides an image file processing library and CMS plugins to manipulate image files, 
+Gallery Magick Image Processing provides an image file processing library and CMS plugins to manipulate image files,
 using any of these:
 - [imgscalr - Java Image-Scaling Library](https://github.com/rkalla/imgscalr)
 - [GraphicsMagick](http://www.graphicsmagick.org/)
 - [ImageMagick](http://www.imagemagick.org/)
 
+# Prerequisites
+
+A native image processing binary must be installed on the server for the `MagickCommandGalleryProcessor` to resize
+images and extract metadata. Without one, uploads will still succeed but images will be stored unresized and without
+dimension metadata.
+
+Install **one** of the following:
+
+**GraphicsMagick** (recommended):
+```bash
+# macOS
+brew install graphicsmagick
+
+# Debian / Ubuntu
+apt-get install graphicsmagick
+
+# RHEL / CentOS
+yum install GraphicsMagick
+```
+
+**ImageMagick**:
+```bash
+# macOS
+brew install imagemagick
+
+# Debian / Ubuntu
+apt-get install imagemagick
+
+# RHEL / CentOS
+yum install ImageMagick
+```
+
+The plugin detects which tool to use via the `magick.image.processor` configuration property in the CMS service
+registration (`magickCommandGalleryProcessorService.yaml`). The default is `GraphicsMagick`.
+
+You can override the binary path with system properties if the executable is not on the server's `PATH`:
+```
+-Dorg.onehippo.forge.gallerymagick.core.command.gm=/usr/local/bin/gm
+-Dorg.onehippo.forge.gallerymagick.core.command.im.convert=/usr/local/bin/convert
+-Dorg.onehippo.forge.gallerymagick.core.command.im.identify=/usr/local/bin/identify
+```
 
 # Documentation (Local)
 
@@ -20,7 +61,7 @@ The output is in the ```target/site/``` directory by default. You can open ```ta
 
 # Documentation (GitHub Pages)
 
-Documentation is available at [https://bloomreach-forge.github.io/content-export-import/](https://bloomreach-forge.github.io/content-export-import/).
+Documentation is available at [https://bloomreach-forge.github.io/gallery-magick/](https://bloomreach-forge.github.io/gallery-magick/).
 
 You can generate the GitHub pages only from ```master``` branch by this command:
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Bootstrap</name>

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -107,7 +107,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing CMS</name>

--- a/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
+++ b/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,10 +224,6 @@ public class MagickCommandGalleryProcessor extends AbstractGalleryProcessor {
         } else {
             return null;
         }
-    }
-
-    public Map<String, ScalingParameters> getScalingParametersMap() {
-        return scalingParametersMap;
     }
 
     @Override

--- a/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
+++ b/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
@@ -159,25 +159,25 @@ public class MagickCommandGalleryProcessor extends AbstractGalleryProcessor {
             log.debug("Unknown image MIME type: {}, using raw data", mimeType);
         }
 
-        ImageDimension dimension = null;
+        final File imageFile = targetFile != null ? targetFile : sourceFile;
+        ImageDimension dimension;
+        try {
+            dimension = identifyDimension(imageFile);
+        } catch (IOException | IllegalArgumentException e) {
+            log.warn("Failed to identify image dimension for '{}', storing with 0x0: {}", imageFile, e.getMessage());
+            dimension = ImageDimension.from(0, 0);
+        }
+
         InputStream imageFileIn = null;
         BufferedInputStream imageBufIn = null;
         Binary imageBinary = null;
 
         try {
-            if (targetFile != null) {
-                dimension = identifyDimension(targetFile);
-                imageFileIn = new FileInputStream(targetFile);
-            } else {
-                dimension = identifyDimension(sourceFile);
-                imageFileIn = new FileInputStream(sourceFile);
-            }
-
+            imageFileIn = new FileInputStream(imageFile);
             imageBufIn = new BufferedInputStream(imageFileIn);
             imageBinary = ResourceHelper.getValueFactory(node).createBinary(imageBufIn);
 
-            log.debug("Storing an image binary at '{}' from file at '{}'.", node.getPath(),
-                    targetFile != null ? targetFile : sourceFile);
+            log.debug("Storing an image binary at '{}' from file at '{}'.", node.getPath(), imageFile);
 
             node.setProperty("jcr:data", imageBinary);
             node.setProperty(HippoGalleryNodeType.IMAGE_WIDTH, (long) dimension.getWidth());

--- a/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
+++ b/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessor.java
@@ -132,7 +132,7 @@ public class MagickCommandGalleryProcessor extends AbstractGalleryProcessor {
         File targetTempFile = null;
 
         if (MimeTypeHelper.isImageMimeType(mimeType)) {
-            final ScalingParameters scalingParameters = getScalingParametersMap().get(nodeName);
+            final ScalingParameters scalingParameters = getScalingParameters(node);
 
             if (scalingParameters != null && scalingParameters.getWidth() > 0 && scalingParameters.getHeight() > 0) {
                 try {
@@ -226,9 +226,18 @@ public class MagickCommandGalleryProcessor extends AbstractGalleryProcessor {
         }
     }
 
-    @Override
-    public Map<String, ScalingParameters> getScalingParametersMap() throws RepositoryException {
+    public Map<String, ScalingParameters> getScalingParametersMap() {
         return scalingParametersMap;
+    }
+
+    @Override
+    public ScalingParameters getScalingParameters(final Node variantNode) {
+        try {
+            return scalingParametersMap.get(variantNode.getName());
+        } catch (RepositoryException e) {
+            log.warn("Unable to get variant node name for scaling parameters", e);
+            return null;
+        }
     }
 
     protected boolean isImageMagickImageProcessor() {

--- a/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessorPlugin.java
+++ b/cms/src/main/java/org/onehippo/forge/gallerymagick/cms/plugins/gallery/processor/MagickCommandGalleryProcessorPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Core</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/ImageDimension.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/ImageDimension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommand.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommand.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommand.java
@@ -206,6 +206,16 @@ abstract public class AbstractMagickCommand {
                 executor.execute(cmdLine, resultHandler);
                 log.debug("Executed with watchdog: {}", cmdLine);
                 resultHandler.waitFor();
+                final ExecuteException handlerException = resultHandler.getException();
+                if (handlerException != null) {
+                    exitValue = resultHandler.getExitValue();
+                    final Throwable cause = handlerException.getCause();
+                    if (cause == null) {
+                        throw new MagickExecuteException(getExecutionErrorMessage(cmdLine, errStream, handlerException), exitValue);
+                    } else {
+                        throw new MagickExecuteException(getExecutionErrorMessage(cmdLine, errStream, handlerException), exitValue, cause);
+                    }
+                }
             } else {
                 exitValue = executor.execute(cmdLine);
                 log.debug("Executed without watchdog: {}", cmdLine);

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommand.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommand.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/MagickExecuteException.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/MagickExecuteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtils.java
+++ b/core/src/main/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractGraphicsMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractGraphicsMagickCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractImageMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractImageMagickCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/AbstractMagickCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/GraphicsMagickCommandUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ImageMagickCommandUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtilsTest.java
+++ b/core/src/test/java/org/onehippo/forge/gallerymagick/core/command/ScalrProcessorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+ * Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -423,7 +423,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>
@@ -471,7 +471,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo</name>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo</name>
   <description>Gallery Magick Image Processing Demo</description>
   <groupId>org.onehippo.forge.gallery-magick</groupId>
   <artifactId>gallery-magick-demo</artifactId>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-repository-data</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-repository-data</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-repository-data</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-repository-data</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-repository-data</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Gallery Magick Image Processing Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-site</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.gallery-magick</groupId>
     <artifactId>gallery-magick-demo-site</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>gallery-magick-demo-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.onehippo.forge.gallery-magick</groupId>
       <artifactId>gallery-magick-demo-components</artifactId>
-      <version>4.1.1-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <imgscalr-lib.version>4.2</imgscalr-lib.version>
-    <commons-exec.version>1.4</commons-exec.version>
+    <commons-exec.version>1.6.0</commons-exec.version>
     <maven.compiler.release>21</maven.compiler.release>
 
     <plugin.jxr.version>2.3</plugin.jxr.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>provided</scope>
       </dependency>
 
@@ -197,12 +197,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j2.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,21 +20,21 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.3.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Gallery Magick Image Processing</name>
   <description>Gallery Magick Image Processing</description>
   <groupId>org.onehippo.forge.gallery-magick</groupId>
   <artifactId>gallery-magick</artifactId>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/bloomreach-forge/gallery-magick</url>
 
   <properties>
     <imgscalr-lib.version>4.2</imgscalr-lib.version>
-    <commons-exec.version>1.3</commons-exec.version>
-    <maven.compiler.release>17</maven.compiler.release>
+    <commons-exec.version>1.4</commons-exec.version>
+    <maven.compiler.release>21</maven.compiler.release>
 
     <plugin.jxr.version>2.3</plugin.jxr.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${junit4.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+  Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>17.0.0</version>
+    <version>17.1.1</version>
   </parent>
 
   <name>Gallery Magick Image Processing</name>
@@ -57,7 +57,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/FORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <licenses>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
   <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
@@ -18,7 +18,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/cms-plugins/configuration.xml
+++ b/src/site/xdoc/cms-plugins/configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/cms-plugins/index.xml
+++ b/src/site/xdoc/cms-plugins/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with

--- a/src/site/xdoc/cms-plugins/install.xml
+++ b/src/site/xdoc/cms-plugins/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/core/dev-howto.xml
+++ b/src/site/xdoc/core/dev-howto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/core/index.xml
+++ b/src/site/xdoc/core/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with

--- a/src/site/xdoc/core/install.xml
+++ b/src/site/xdoc/core/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/faq.xml
+++ b/src/site/xdoc/faq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with

--- a/src/site/xdoc/prerequisites.xml
+++ b/src/site/xdoc/prerequisites.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright 2024 Bloomreach B.V. (http://www.bloomreach.com)
+    Copyright 2026 Bloomreach B.V. (http://www.bloomreach.com)
 
     Licensed under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
@@ -29,6 +29,10 @@
           </th>
         </tr>
         <tr>
+          <td>5.x</td>
+          <td>17.x</td>
+        </tr>
+        <tr>
           <td>4.x</td>
           <td>16.x</td>
         </tr>
@@ -45,6 +49,15 @@
           <td>10.x, 11.x</td>
         </tr>
       </table>
+    </section>
+    <section name="Release Notes of 5.x">
+      <subsection name="5.0.0">
+        <p class="smallinfo">Release Date: 15 July 2026</p>
+        <ul>
+          <li>[<a href='https://bloomreach.atlassian.net/browse/FORGE-618'>FORGE-618</a>] - Upgrade plugin to v17
+          </li>
+        </ul>
+      </subsection>
     </section>
     <section name="Release Notes of 4.x">
       <subsection name="4.1.0">


### PR DESCRIPTION
  Upgrade gallery-magick to BrXM v17 (FORGE-618)

  - hippo-cms7-release parent bumped 16.x → 17.0.0 across all pom files
  - Project version advanced to 5.0.0-SNAPSHOT per forge major-version convention
  - Java compiler target 17 → 21 (JDK 21 platform requirement)
  - commons-exec 1.3 → 1.6.0; slf4j.version → slf4j2.version; log4j-slf4j-impl → log4j-slf4j2-impl; junit.version → junit4.version (all v17 BOM renames)
  - GalleryProcessor.getScalingParametersMap() removed in v17 — replaced with getScalingParameters(Node)
  - Fixed AbstractMagickCommand swallowing async execution failures silently (commons-exec 1.6.0 behaviour change)
  - Fixed upload crash when gm/im not installed — dimension identification now falls back to 0×0 instead of aborting binary storage
  - support/4.x maintenance branch created to preserve the v16 line
  - README: added native binary prerequisites + fixed stale docs URL